### PR TITLE
Added config options for proxy and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ gem "lita-slack"
 
 * `token` (String) – The bot's Slack API token. Create a bot and get its token at https://my.slack.com/services/new/lita.
 
+### Optional attributes
+
+* `endpoint` (String) – The URL to use for the slack API.  Defaults to "https://slack.com/api".
+* `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.mydomain.com:3128")
+
 **Note**: When using lita-slack, the adapter will overwrite the bot's name and mention name with the values set on the server, so `config.robot.name` and `config.robot.mention_name` will have no effect.
 
 ### config.robot.admins

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -5,12 +5,21 @@ module Lita
     class Slack < Adapter
       # Required configuration attributes.
       config :token, type: String, required: true
+      config :endpoint, type: String, required: false
+      config :proxy, type: String, required: false
 
       # Starts the connection.
       def run
         return if rtm_connection
 
-        @rtm_connection = RTMConnection.build(robot, config.token)
+        @rtm_connection = RTMConnection.build(
+          robot,
+          {
+            token: config.token,
+            endpoint: config.endpoint,
+            proxy: config.proxy
+          }
+        )
         rtm_connection.run
       end
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -34,10 +34,10 @@ module Lita
       attr_reader :rtm_connection
 
       def channel_for(target)
-        if target.room
-          target.room
-        else
+        if target.private_message?
           rtm_connection.im_for(target.user.id)
+        else
+          target.room
         end
       end
     end

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -5,21 +5,14 @@ module Lita
     class Slack < Adapter
       # Required configuration attributes.
       config :token, type: String, required: true
-      config :endpoint, type: String, required: false
-      config :proxy, type: String, required: false
+      config :endpoint, type: String, default: "https://slack.com/api"
+      config :proxy, type: String
 
       # Starts the connection.
       def run
         return if rtm_connection
 
-        @rtm_connection = RTMConnection.build(
-          robot,
-          {
-            token: config.token,
-            endpoint: config.endpoint,
-            proxy: config.proxy
-          }
-        )
+        @rtm_connection = RTMConnection.build(robot, config)
         rtm_connection.run
       end
 

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -9,9 +9,7 @@ module Lita
     class Slack < Adapter
       class API
         def initialize(config, stubs = nil)
-          @token = config[:token]
-          @endpoint = config[:endpoint] || "https://slack.com/api"
-          @proxy = config[:proxy]
+          @config = config
           @stubs = stubs
         end
 
@@ -35,14 +33,12 @@ module Lita
         private
 
         attr_reader :stubs
-        attr_reader :token
-        attr_reader :proxy
-        attr_reader :endpoint
+        attr_reader :config
 
         def call_api(method, post_data = {})
           response = connection.post(
-            "#{endpoint}/#{method}",
-            { token: token }.merge(post_data)
+            "#{config.endpoint}/#{method}",
+            { token: config.token }.merge(post_data)
           )
 
           data = parse_response(response, method)
@@ -57,11 +53,8 @@ module Lita
             Faraday.new { |faraday| faraday.adapter(:test, stubs) }
           else
             options = {}
-            if !proxy.nil?
-              options = {
-                ssl: {verify:false},
-                proxy: proxy
-              }
+            unless config.proxy.nil?
+              options = { proxy: config.proxy }
             end
             Faraday.new(options)
           end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -43,7 +43,9 @@ module Lita
 
         def dispatch_message(user)
           source = Source.new(user: user, room: channel)
+          source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
+          message.command! if source.private_message?
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)
         end

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -22,7 +22,7 @@ module Lita
         def initialize(robot, config, team_data)
           @robot = robot
           @config = config
-          @im_mapping = IMMapping.new(config[:token], team_data.ims)
+          @im_mapping = IMMapping.new(config.token, team_data.ims)
           @websocket_url = team_data.websocket_url
           @robot_id = team_data.self.id
 
@@ -37,8 +37,8 @@ module Lita
           EM.run do
             log.debug("Connecting to the Slack Real Time Messaging API.")
             options = { ping: 10 }
-            if !@config[:proxy].nil?
-              options[:proxy] = { :origin => @config[:proxy] }
+            unless @config.proxy.nil?
+              options[:proxy] = { :origin => @config.proxy }
             end
             @websocket = Faye::WebSocket::Client.new(websocket_url, nil, options)
 

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -22,7 +22,7 @@ module Lita
         def initialize(robot, config, team_data)
           @robot = robot
           @config = config
-          @im_mapping = IMMapping.new(config.token, team_data.ims)
+          @im_mapping = IMMapping.new(API.new(config), team_data.ims)
           @websocket_url = team_data.websocket_url
           @robot_id = team_data.self.id
 

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-slack"
-  spec.version       = "1.0.4"
+  spec.version       = "1.0.5"
   spec.authors       = ["Ken J.", "Jimmy Cuadra"]
   spec.email         = ["kenjij@gmail.com", "jimmy@jimmycuadra.com"]
   spec.description   = %q{Lita adapter for Slack.}

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-slack"
-  spec.version       = "1.0.3"
+  spec.version       = "1.0.4"
   spec.authors       = ["Ken J.", "Jimmy Cuadra"]
   spec.email         = ["kenjij@gmail.com", "jimmy@jimmycuadra.com"]
   spec.description   = %q{Lita adapter for Slack.}

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -5,15 +5,11 @@ describe Lita::Adapters::Slack::API do
 
   let(:http_status) { 200 }
   let(:token) { 'abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y' }
-  let(:registry) { Lita::Registry.new }
-  let(:robot) { Lita::Robot.new(registry) }
+  let(:config) { Lita::Adapters::Slack.configuration_builder.build }
 
   before do
-    registry.register_adapter(:slack, Lita::Adapters::Slack)
-    registry.config.adapters.slack.token = token
+    config.token = token
   end
-
-  let(:config) { registry.adapters[:slack].new(robot).config }
 
   describe "#im_open" do
     let(:channel_id) { 'D024BFF1M' }

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -1,10 +1,19 @@
 require "spec_helper"
 
 describe Lita::Adapters::Slack::API do
-  subject { described_class.new(token, stubs) }
+  subject { described_class.new(config, stubs) }
 
   let(:http_status) { 200 }
   let(:token) { 'abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y' }
+  let(:registry) { Lita::Registry.new }
+  let(:robot) { Lita::Robot.new(registry) }
+
+  before do
+    registry.register_adapter(:slack, Lita::Adapters::Slack)
+    registry.config.adapters.slack.token = token
+  end
+
+  let(:config) { registry.adapters[:slack].new(robot).config }
 
   describe "#im_open" do
     let(:channel_id) { 'D024BFF1M' }

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -25,13 +25,11 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   let(:token) { 'abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y' }
   let(:queue) { Queue.new }
   let(:proxy_url) { "http://foo:3128" }
+  let(:config) { Lita::Adapters::Slack.configuration_builder.build }
 
   before do
-    registry.register_adapter(:slack, Lita::Adapters::Slack)
-    registry.config.adapters.slack.token = token
+    config.token = token
   end
-
-  let(:config) { registry.adapters[:slack].new(robot).config }
 
   describe ".build" do
     before do
@@ -79,7 +77,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
     end
 
     before do
-      registry.config.adapters.slack.proxy = proxy_url
+      config.proxy = proxy_url
     end
 
     it "creates the WebSocket specifying a proxy" do

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -9,7 +9,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
     thread.join
   end
 
-  subject { described_class.new(robot, token, rtm_start_response) }
+  subject { described_class.new(robot, config, rtm_start_response) }
 
   let(:api) { instance_double("Lita::Adapters::Slack::API") }
   let(:registry) { Lita::Registry.new }
@@ -24,21 +24,29 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   end
   let(:token) { 'abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y' }
   let(:queue) { Queue.new }
+  let(:proxy_url) { "http://foo:3128" }
+
+  before do
+    registry.register_adapter(:slack, Lita::Adapters::Slack)
+    registry.config.adapters.slack.token = token
+  end
+
+  let(:config) { registry.adapters[:slack].new(robot).config }
 
   describe ".build" do
     before do
-      allow(Lita::Adapters::Slack::API).to receive(:new).with(token).and_return(api)
+      allow(Lita::Adapters::Slack::API).to receive(:new).with(config).and_return(api)
       allow(api).to receive(:rtm_start).and_return(rtm_start_response)
     end
 
     it "constructs a new RTMConnection with the results of rtm.start data" do
-      expect(described_class.build(robot, token)).to be_an_instance_of(described_class)
+      expect(described_class.build(robot, config)).to be_an_instance_of(described_class)
     end
 
     it "creates users with the results of rtm.start data" do
       expect(Lita::Adapters::Slack::UserCreator).to receive(:create_users)
 
-      described_class.build(robot, token)
+      described_class.build(robot, config)
     end
   end
 
@@ -65,6 +73,16 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
     end
 
     it "creates the WebSocket" do
+      with_websocket(subject, queue) do |websocket|
+        expect(websocket).to be_an_instance_of(Faye::WebSocket::Client)
+      end
+    end
+
+    before do
+      registry.config.adapters.slack.proxy = proxy_url
+    end
+
+    it "creates the WebSocket specifying a proxy" do
       with_websocket(subject, queue) do |websocket|
         expect(websocket).to be_an_instance_of(Faye::WebSocket::Client)
       end

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -50,7 +50,10 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
 
   describe "#im_for" do
     before do
-      allow(Lita::Adapters::Slack::IMMapping).to receive(:new).and_return(im_mapping)
+      allow(Lita::Adapters::Slack::API).to receive(:new).with(config).and_return(api)
+      allow(
+        Lita::Adapters::Slack::IMMapping
+      ).to receive(:new).with(api, []).and_return(im_mapping)
       allow(im_mapping).to receive(:im_for).with('U12345678').and_return('D024BFF1M')
     end
 

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -40,6 +40,9 @@ describe Lita::Adapters::Slack, lita: true do
     let(:room_source) { Lita::Source.new(room: 'C024BE91L') }
     let(:user) { Lita::User.new('U023BECGF') }
     let(:user_source) { Lita::Source.new(user: user) }
+    let(:private_message_source) do
+      Lita::Source.new(room: 'C024BE91L', user: user, private_message: true)
+    end
 
     it "sends messages to rooms" do
       expect(rtm_connection).to receive(:send_messages).with(room_source.room, ['foo'])
@@ -56,7 +59,17 @@ describe Lita::Adapters::Slack, lita: true do
 
       subject.run
 
-      subject.send_messages(Lita::Source.new(user: user), ['foo'])
+      subject.send_messages(user_source, ['foo'])
+    end
+
+    it "sends messages to users when the source is marked as a private message" do
+      allow(rtm_connection).to receive(:im_for).with(user.id).and_return('D024BFF1M')
+
+      expect(rtm_connection).to receive(:send_messages).with('D024BFF1M', ['foo'])
+
+      subject.run
+
+      subject.send_messages(private_message_source, ['foo'])
     end
   end
 

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -13,7 +13,7 @@ describe Lita::Adapters::Slack, lita: true do
 
     allow(
       described_class::RTMConnection
-    ).to receive(:build).with(robot, token).and_return(rtm_connection)
+    ).to receive(:build).with(robot, subject.config).and_return(rtm_connection)
     allow(rtm_connection).to receive(:run)
   end
 


### PR DESCRIPTION
This modification allows users to specify an HTTP proxy and specify which URL to use for the Slack API.  Specifying the API endpoint is useful when using URLs in the form: https://my_company.slack.com.