### PR TITLE
Add slack user timezone

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -15,8 +15,10 @@ module Lita
             handle_hello
           when "message"
             handle_message
-          when "user_change", "team_join"
+          when "user_change"
             handle_user_change
+          when "team_join"
+            handle_team_join
           when "bot_added", "bot_changed"
             handle_bot_change
           when "error"
@@ -94,6 +96,12 @@ module Lita
         def handle_user_change
           log.debug("Updating user data.")
           UserCreator.create_user(SlackUser.from_data(data["user"]), robot, robot_id)
+        end
+        
+        def handle_team_join
+          handle_user_change
+          log.info("#{SlackUser.from_data(data['user']).name} joined the team")
+          robot.trigger(:team_join, user: SlackUser.from_data(data["user"]).name)
         end
 
         def log

--- a/lib/lita/adapters/slack/slack_user.rb
+++ b/lib/lita/adapters/slack/slack_user.rb
@@ -7,7 +7,8 @@ module Lita
             new(
               user_data['id'],
               user_data['name'],
-              user_data['real_name']
+              user_data['real_name'],
+              user_data['tz']
             )
           end
 
@@ -19,11 +20,13 @@ module Lita
         attr_reader :id
         attr_reader :name
         attr_reader :real_name
+        attr_reader :tz
 
-        def initialize(id, name, real_name)
+        def initialize(id, name, real_name, tz)
           @id = id
           @name = name
           @real_name = real_name.to_s
+          @tz = tz
         end
       end
     end

--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -6,9 +6,9 @@ module Lita
           def create_user(slack_user, robot, robot_id)
             User.create(
               slack_user.id,
-              name: slack_user.name #real_name(slack_user),
-              mention_name: slack_user.name
-              metadata: {"tz" => slack_user.tz}
+              name: slack_user.name,
+              mention_name: slack_user.name,
+              tz: slack_user.tz
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id

--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -6,7 +6,7 @@ module Lita
           def create_user(slack_user, robot, robot_id)
             User.create(
               slack_user.id,
-              name: real_name(slack_user),
+              name: slack_user.name #real_name(slack_user),
               mention_name: slack_user.name
               metadata: {"tz" => slack_user.tz}
             )

--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -8,6 +8,7 @@ module Lita
               slack_user.id,
               name: real_name(slack_user),
               mention_name: slack_user.name
+              metadata: {"tz" => slack_user.tz}
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id


### PR DESCRIPTION
There are many metadata attributes in the slack_user object, that make sense to be used.
I tried the whole process with timezone f.e. just to be clear how this could be achieved.
As i also changed the real_name to screen_name, maybe this pull request in its entire doesn't make sense for the master project.