### PR TITLE
Defer the message handling so that slow handler to not freeze Lita

### DIFF
--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -92,9 +92,11 @@ module Lita
         end
 
         def receive_message(event)
-          data = MultiJson.load(event.data)
+          EM.defer do
+            data = MultiJson.load(event.data)
 
-          MessageHandler.new(robot, robot_id, data).handle
+            MessageHandler.new(robot, robot_id, data).handle
+          end
         end
 
         def safe_payload_for(channel, string)


### PR DESCRIPTION
@jimmycuadra 

This fixes both https://github.com/jimmycuadra/lita/pull/79 and https://github.com/jimmycuadra/lita/pull/77