### PR TITLE
Trigger :slack_user_created event with raw data

### DIFF
--- a/lib/lita/adapters/slack/slack_user.rb
+++ b/lib/lita/adapters/slack/slack_user.rb
@@ -7,7 +7,8 @@ module Lita
             new(
               user_data['id'],
               user_data['name'],
-              user_data['real_name']
+              user_data['real_name'],
+              user_data
             )
           end
 
@@ -19,11 +20,13 @@ module Lita
         attr_reader :id
         attr_reader :name
         attr_reader :real_name
+        attr_reader :raw_data
 
-        def initialize(id, name, real_name)
+        def initialize(id, name, real_name, raw_data)
           @id = id
           @name = name
           @real_name = real_name.to_s
+          @raw_data = raw_data
         end
       end
     end

--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -11,7 +11,7 @@ module Lita
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id
-            robot.trigger(:slack_user_created, user_id: slack_user.id, raw_data: slack_user.raw_data)
+            robot.trigger(:slack_user_created, slack_user: slack_user.raw_data)
           end
 
           def create_users(slack_users, robot, robot_id)

--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -11,6 +11,7 @@ module Lita
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id
+            robot.trigger(:slack_user_created, user_id: slack_user.id, raw_data: slack_user.raw_data)
           end
 
           def create_users(slack_users, robot, robot_id)

--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -11,7 +11,7 @@ module Lita
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id
-            robot.trigger(:slack_user_created, slack_user: slack_user.raw_data)
+            robot.trigger(:slack_user_created, slack_user: slack_user)
           end
 
           def create_users(slack_users, robot, robot_id)

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -14,11 +14,12 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   let(:api) { instance_double("Lita::Adapters::Slack::API") }
   let(:registry) { Lita::Registry.new }
   let(:robot) { Lita::Robot.new(registry) }
+  let(:raw_user_data) { Hash.new }
   let(:rtm_start_response) do
     Lita::Adapters::Slack::TeamData.new(
       [],
-      Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', nil),
-      [Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', '')],
+      Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', nil, raw_user_data),
+      [Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', '', raw_user_data)],
       "wss://example.com/"
     )
   end

--- a/spec/lita/adapters/slack/user_creator_spec.rb
+++ b/spec/lita/adapters/slack/user_creator_spec.rb
@@ -5,16 +5,29 @@ describe Lita::Adapters::Slack::UserCreator do
 
   let(:robot) { instance_double('Lita::Robot') }
 
+  before do
+    allow(robot).to receive(:trigger).with(
+      :slack_user_created,
+      hash_including(:user_id, :raw_data)
+    )
+  end
+
   describe ".create_users" do
     let(:real_name) { 'Bobby Tables' }
-    let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name) }
+    let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, raw_data) }
     let(:robot_id) { 'U12345678' }
+    let(:raw_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name } }
 
     it "creates Lita users for each user in the provided data" do
       expect(Lita::User).to receive(:create).with(
         'U023BECGF',
         name: 'Bobby Tables',
         mention_name: 'bobby'
+      )
+      expect(robot).to receive(:trigger).with(
+        :slack_user_created,
+        user_id: 'U023BECGF',
+        raw_data: raw_data
       )
 
       described_class.create_users([bobby], robot, robot_id)
@@ -37,7 +50,8 @@ describe Lita::Adapters::Slack::UserCreator do
 
   describe ".create_user" do
     let(:robot_id) { 'U12345678' }
-    let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot') }
+    let(:raw_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot' } }
+    let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot', raw_data) }
 
     it "updates the robot's name and mention name if it applicable" do
       expect(robot).to receive(:name=).with('Lita Bot')

--- a/spec/lita/adapters/slack/user_creator_spec.rb
+++ b/spec/lita/adapters/slack/user_creator_spec.rb
@@ -25,7 +25,7 @@ describe Lita::Adapters::Slack::UserCreator do
       )
       expect(robot).to receive(:trigger).with(
         :slack_user_created,
-        slack_user: slack_data
+        slack_user: bobby
       )
 
       described_class.create_users([bobby], robot, robot_id)

--- a/spec/lita/adapters/slack/user_creator_spec.rb
+++ b/spec/lita/adapters/slack/user_creator_spec.rb
@@ -7,16 +7,15 @@ describe Lita::Adapters::Slack::UserCreator do
 
   before do
     allow(robot).to receive(:trigger).with(
-      :slack_user_created,
-      hash_including(:user_id, :raw_data)
+      :slack_user_created, hash_including(:slack_user)
     )
   end
 
   describe ".create_users" do
     let(:real_name) { 'Bobby Tables' }
-    let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, raw_data) }
+    let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, slack_data) }
     let(:robot_id) { 'U12345678' }
-    let(:raw_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name } }
+    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name } }
 
     it "creates Lita users for each user in the provided data" do
       expect(Lita::User).to receive(:create).with(
@@ -26,8 +25,7 @@ describe Lita::Adapters::Slack::UserCreator do
       )
       expect(robot).to receive(:trigger).with(
         :slack_user_created,
-        user_id: 'U023BECGF',
-        raw_data: raw_data
+        slack_user: slack_data
       )
 
       described_class.create_users([bobby], robot, robot_id)
@@ -50,8 +48,8 @@ describe Lita::Adapters::Slack::UserCreator do
 
   describe ".create_user" do
     let(:robot_id) { 'U12345678' }
-    let(:raw_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot' } }
-    let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot', raw_data) }
+    let(:slack_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot' } }
+    let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot', slack_data) }
 
     it "updates the robot's name and mention name if it applicable" do
       expect(robot).to receive(:name=).with('Lita Bot')


### PR DESCRIPTION
We need to keep some Slack user information synchronized with other components of our setup. Upon such a change, Slack will send the "user_change" message, which lita-slack handles via `UserCreator.create_user`. The :slack_user_created even will also be triggered when the adapter first connects, via the `RTMConnection` and `UserCreator.create_users`.

This event allows us to handle all such updates in a pretty independent and decoupled manner.

This solution should also solve #19.