### PR TITLE
Defer creating all users on connection.

### DIFF
--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -26,7 +26,9 @@ module Lita
           @websocket_url = team_data.websocket_url
           @robot_id = team_data.self.id
 
-          UserCreator.create_users(team_data.users, robot, robot_id)
+          EventLoop.defer do
+            UserCreator.create_users(team_data.users, robot, robot_id)
+          end
         end
 
         def im_for(user_id)

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -43,6 +43,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
     end
 
     it "creates users with the results of rtm.start data" do
+      allow(Lita::Adapters::Slack::EventLoop).to receive(:defer).and_yield
       expect(Lita::Adapters::Slack::UserCreator).to receive(:create_users)
 
       described_class.build(robot, config)


### PR DESCRIPTION
If we have A LOT of users, and especially if we're leveraging the
:slack_user_created event triggered by UserCreator.create_user, the
Slack Websocket can "time out." We only have 30 seconds to use a
connection once it's given to us.

This change defers the blocking, and possibly long-ish running creation
of all uses to a background EM thread.