### PR TITLE
remove url formatting on slack messages

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -3,6 +3,7 @@ require 'faraday'
 require 'lita/adapters/slack/team_data'
 require 'lita/adapters/slack/slack_im'
 require 'lita/adapters/slack/slack_user'
+require 'lita/adapters/slack/slack_channel'
 
 module Lita
   module Adapters
@@ -19,6 +20,17 @@ module Lita
           SlackIM.new(response_data["channel"]["id"], user_id)
         end
 
+        def channel_create(channel_name)
+          response_data = call_api("channels.create", name: channel_name)
+
+          SlackChannel.new(
+              response_data["channel"]["id"],
+              response_data["channel"]["name"],
+              response_data["channel"]["created"],
+              response_data["channel"]["creator"],
+              response_data)
+        end
+
         def set_topic(channel, topic)
           call_api("channels.setTopic", channel: channel, topic: topic)
         end
@@ -30,6 +42,7 @@ module Lita
             SlackIM.from_data_array(response_data["ims"]),
             SlackUser.from_data(response_data["self"]),
             SlackUser.from_data_array(response_data["users"]),
+            SlackChannel.from_data_array(response_data["channels"]),
             response_data["url"]
           )
         end

--- a/lib/lita/adapters/slack/channel_mapping.rb
+++ b/lib/lita/adapters/slack/channel_mapping.rb
@@ -1,0 +1,31 @@
+module Lita
+  module Adapters
+    class Slack < Adapter
+      class
+      ChannelMapping
+        def initialize(channels)
+
+          @mapping = {}
+
+          add_mappings(channels)
+        end
+
+        def add_mapping(channel)
+          mapping[channel.id] = channel.name
+        end
+
+        def add_mappings(channels)
+          channels.each { |channel| add_mapping(channel) }
+        end
+
+        def channel_for(channel_id)
+          mapping.fetch(channel_id)
+        end
+
+        private
+
+        attr_reader :mapping
+      end
+    end
+  end
+end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -95,7 +95,7 @@ module Lita
                 if label && !(link.include? label)
                   "#{label} (#{link})"
                 else
-                  label
+                  label == nil ? link : label
                 end
             end
           end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -85,7 +85,7 @@ module Lita
                 if label and not link.include? label
                   "#{label} (#{link})"
                 else
-                  link
+                  label
                 end
             end
           end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -57,7 +57,7 @@ module Lita
                   (?<label>[^>]+)  # label
               )?                   # end of label
               >                    # closing angle bracket
-              /i) do
+              /ix) do
             link  = Regexp.last_match[:link]
             label = Regexp.last_match[:label]
 

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -49,7 +49,15 @@ module Lita
 
         def remove_formatting(message)
           # https://api.slack.com/docs/formatting
-          message = message.gsub(/<(?<type>[@#!])?(?<link>[^>|]+)(?:\|(?<label>[^>]+))?>/i) do
+          message = message.gsub(/
+              <                    # opening angle bracket
+              (?<type>[@#!])?      # link type
+              (?<link>[^>|]+)      # link
+              (?:\|                # start of |label (optional)
+                  (?<label>[^>]+)  # label
+              )?                   # end of label
+              >                    # closing angle bracket
+              /i) do
             link  = Regexp.last_match[:link]
             label = Regexp.last_match[:label]
 

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -90,7 +90,7 @@ module Lita
                 "@#{link}" if ['channel', 'group', 'everyone'].include? link
               else
                 link = link.gsub /^mailto:/, ''
-                if label && !link.include? label
+                if label && !(link.include? label)
                   "#{label} (#{link})"
                 else
                   label

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -2,11 +2,12 @@ module Lita
   module Adapters
     class Slack < Adapter
       class MessageHandler
-        def initialize(robot, robot_id, data)
+        def initialize(robot, robot_id, data, channel_mapping)
           @robot = robot
           @robot_id = robot_id
           @data = data
           @type = data["type"]
+          @channel_mapping = channel_mapping
         end
 
         def handle
@@ -32,6 +33,7 @@ module Lita
         attr_reader :robot
         attr_reader :robot_id
         attr_reader :type
+        attr_reader :channel_mapping
 
         def body
           normalized_message = if data["text"]

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -66,7 +66,7 @@ module Lita
                 if label
                   label
                 else
-                  user = User.find_by_id link
+                  user = User.find_by_id(link)
                   if user
                     "@#{user.name}"
                   else
@@ -78,7 +78,7 @@ module Lita
                 if label
                   label
                 else
-                  channel = @channel_mapping.channel_for link
+                  channel = @channel_mapping.channel_for(link)
                   if channel
                     "\##{channel}"
                   else
@@ -90,7 +90,7 @@ module Lita
                 "@#{link}" if ['channel', 'group', 'everyone'].include? link
               else
                 link = link.gsub /^mailto:/, ''
-                if label and not link.include? label
+                if label && !link.include? label
                   "#{label} (#{link})"
                 else
                   label

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -36,6 +36,8 @@ module Lita
         def body
           normalized_message = if data["text"]
             data["text"].sub(/^\s*<@#{robot_id}>/, "@#{robot.mention_name}")
+            .gsub(/<http:\/\/([\S]*)\|[\S]*>/, '\1')
+            .gsub(/<(http:\/\/[\S]*)>/, '\1')
           end
 
           attachment_text = Array(data["attachments"]).map do |attachment|

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -4,6 +4,7 @@ require 'multi_json'
 require 'lita/adapters/slack/api'
 require 'lita/adapters/slack/event_loop'
 require 'lita/adapters/slack/im_mapping'
+require 'lita/adapters/slack/channel_mapping'
 require 'lita/adapters/slack/message_handler'
 require 'lita/adapters/slack/user_creator'
 
@@ -23,6 +24,7 @@ module Lita
           @robot = robot
           @config = config
           @im_mapping = IMMapping.new(API.new(config), team_data.ims)
+          @channel_mapping = ChannelMapping.new(team_data.channels)
           @websocket_url = team_data.websocket_url
           @robot_id = team_data.self.id
 
@@ -73,6 +75,7 @@ module Lita
 
         attr_reader :config
         attr_reader :im_mapping
+        attr_reader :channel_mapping
         attr_reader :robot
         attr_reader :robot_id
         attr_reader :websocket
@@ -94,7 +97,7 @@ module Lita
         def receive_message(event)
           data = MultiJson.load(event.data)
 
-          EventLoop.defer { MessageHandler.new(robot, robot_id, data).handle }
+          EventLoop.defer { MessageHandler.new(robot, robot_id, data, channel_mapping).handle }
         end
 
         def safe_payload_for(channel, string)

--- a/lib/lita/adapters/slack/slack_channel.rb
+++ b/lib/lita/adapters/slack/slack_channel.rb
@@ -1,0 +1,37 @@
+module Lita
+  module Adapters
+    class Slack < Adapter
+      class SlackChannel
+        class << self
+          def from_data(channel_data)
+            new(
+                channel_data['id'],
+                channel_data['name'],
+                channel_data['created'],
+                channel_data['creator'],
+                channel_data
+            )
+          end
+
+          def from_data_array(channels_data)
+            channels_data.map { |channel_data| from_data(channel_data) }
+          end
+        end
+
+        attr_reader :id
+        attr_reader :name
+        attr_reader :created
+        attr_reader :creator
+        attr_reader :raw_data
+
+        def initialize(id, name, created, creator, raw_data)
+          @id       = id
+          @name     = name
+          @created  = created
+          @creator  = creator
+          @raw_data = raw_data
+        end
+      end
+    end
+  end
+end

--- a/lib/lita/adapters/slack/team_data.rb
+++ b/lib/lita/adapters/slack/team_data.rb
@@ -1,7 +1,7 @@
 module Lita
   module Adapters
     class Slack < Adapter
-      TeamData = Struct.new(:ims, :self, :users, :websocket_url)
+      TeamData = Struct.new(:ims, :self, :users, :channels, :websocket_url)
     end
   end
 end

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -141,7 +141,8 @@ describe Lita::Adapters::Slack::API do
           url: 'wss://example.com/',
           users: [{ id: 'U023BECGF' }],
           ims: [{ id: 'D024BFF1M' }],
-          self: { id: 'U12345678' }
+          self: { id: 'U12345678' },
+          channels: [{ id: 'C1234567890' }]
         })
       end
 

--- a/spec/lita/adapters/slack/channel_mapping_spec.rb
+++ b/spec/lita/adapters/slack/channel_mapping_spec.rb
@@ -4,9 +4,7 @@ describe Lita::Adapters::Slack::ChannelMapping do
   subject { described_class.new(channels) }
 
   let(:api) { instance_double('Lita::Adapters::Slack::API') }
-  let(:channel) { Lita::Adapters::Slack::SlackChannel.new('C1234567890', 'Room 10', 1360782804, 'U023BECGF', raw_data) }
-  let(:raw_data) { Hash.new }
-
+  let(:channel) { Lita::Adapters::Slack::SlackChannel.new('C1234567890', 'Room 10', 1360782804, 'U023BECGF', Hash.new ) }
 
   describe "#channel_for" do
     context "when a mapping is already stored" do
@@ -16,20 +14,6 @@ describe Lita::Adapters::Slack::ChannelMapping do
         expect(subject.channel_for('C1234567890')).to eq('Room 10')
       end
     end
-
-=begin
-    context "when a channel is not yet created" do
-      before do
-        allow(api).to receive(:channel_create).with('Room 10').and_return(channel).once
-      end
-
-
-      let(:channels) { [] }
-
-      it "fetch the channel name from the API using the channel id" do
-        expect(subject.channel_for('C1234567890')).to eq('Room 10')
-      end
-    end
-=end
   end
+
 end

--- a/spec/lita/adapters/slack/channel_mapping_spec.rb
+++ b/spec/lita/adapters/slack/channel_mapping_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe Lita::Adapters::Slack::ChannelMapping do
+  subject { described_class.new(channels) }
+
+  let(:api) { instance_double('Lita::Adapters::Slack::API') }
+  let(:channel) { Lita::Adapters::Slack::SlackChannel.new('C1234567890', 'Room 10', 1360782804, 'U023BECGF', raw_data) }
+  let(:raw_data) { Hash.new }
+
+
+  describe "#channel_for" do
+    context "when a mapping is already stored" do
+      let(:channels) { [channel] }
+
+      it "returns the Channel name for the given channel ID" do
+        expect(subject.channel_for('C1234567890')).to eq('Room 10')
+      end
+    end
+
+=begin
+    context "when a channel is not yet created" do
+      before do
+        allow(api).to receive(:channel_create).with('Room 10').and_return(channel).once
+      end
+
+
+      let(:channels) { [] }
+
+      it "fetch the channel name from the API using the channel id" do
+        expect(subject.channel_for('C1234567890')).to eq('Room 10')
+      end
+    end
+=end
+  end
+end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -409,6 +409,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "remove formatting around <mailto> links with an email label" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <mailto:name@example.com|name@example.com> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo name@example.com bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -301,6 +301,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "changes <!group> links to @group" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <!group> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo @group bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -140,6 +140,29 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           subject.handle
         end
       end
+
+
+      context "when the message has some formatting" do
+        let(:data) do
+          {
+              "type"    => "message",
+              "channel" => "C2147483705",
+              "user"    => "U023BECGF",
+              "text"    => "@name #channel http://slack.com slack.com email@slack.com &amp; &lt; &gt;",
+          }
+        end
+
+        it "formats text" do
+          expect(Lita::Message).to receive(:new).with(
+            robot,
+            "@name #channel http://slack.com slack.com email@slack.com & < >",
+            source
+          ).and_return(message)
+
+          subject.handle
+        end
+
+      end
     end
 
     context "with a message with an unsupported subtype" do

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -373,6 +373,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "remove formatting around <http> links with a label containing entities" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <http://www.example.com|label &gt; &amp; &lt;> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo label > & < (http://www.example.com) bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -283,6 +283,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "changes  <!channel> links to @channel" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <!channel> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo @channel bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -265,6 +265,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "changes <!everyone> links to @everyone" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <!everyone> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo @everyone bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -391,6 +391,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "remove formatting around around <mailto> links" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <mailto:name@example.com> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo name@example.com bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -427,6 +427,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "change multiple links at once" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <@U123|label> bar <#C2147483705> <!channel> <http://www.example.com|label>",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo label bar #general @channel label (http://www.example.com)",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -319,6 +319,42 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "removes remove formatting around <http> links" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <http://www.example.com> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo http://www.example.com bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
+        context "removes remove formatting around <http> links with a substring label" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <http://www.example.com|www.example.com> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo www.example.com bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -142,6 +142,9 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       end
 
       describe "Removing message formatting" do
+
+        let(:user) { instance_double('Lita::User', id: 'U123',name: 'name', mention_name: 'label') }
+
         context "does nothing if there are no user links" do
           let(:data) do
             {
@@ -181,6 +184,44 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
             subject.handle
           end
 
+        end
+
+        context "changes <@123> links to @name" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <@123> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo @name bar",
+                                         source
+                                     ).and_return(message)
+
+            subject.handle
+          end
+        end
+
+        context "changes <@U123|label> links to label" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <@123|label> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo label bar",
+                                         source
+                                     ).and_return(message)
+
+            subject.handle
+          end
         end
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -141,27 +141,47 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
         end
       end
 
+      describe "Removing message formatting" do
+        context "does nothing if there are no user links" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo",
+            }
+          end
 
-      context "when the message has some formatting" do
-        let(:data) do
-          {
-              "type"    => "message",
-              "channel" => "C2147483705",
-              "user"    => "U023BECGF",
-              "text"    => "@name #channel http://slack.com slack.com email@slack.com &amp; &lt; &gt;",
-          }
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo",
+                                         source
+                                     ).and_return(message)
+
+            subject.handle
+          end
+
         end
+        context "decodes entities" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo &gt; &amp; &lt; &gt;&amp;&lt;",
+            }
+          end
 
-        it "formats text" do
-          expect(Lita::Message).to receive(:new).with(
-            robot,
-            "@name #channel http://slack.com slack.com email@slack.com & < >",
-            source
-          ).and_return(message)
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo > & < >&<",
+                                         source
+                                     ).and_return(message)
 
-          subject.handle
+            subject.handle
+          end
+
         end
-
       end
     end
 

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -355,6 +355,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "remove formatting around <skype> links" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <skype:echo123?call> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo skype:echo123?call bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
 
       end
     end

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -96,6 +96,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
 
     it "dispatches incoming data to MessageHandler" do
       allow(Lita::Adapters::Slack::EventLoop).to receive(:defer).and_yield
+      allow(subject).to receive(:channel_mapping).and_return(channel_mapping)
       allow(Lita::Adapters::Slack::MessageHandler).to receive(:new).with(
         robot,
         'U12345678',

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -15,11 +15,16 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   let(:registry) { Lita::Registry.new }
   let(:robot) { Lita::Robot.new(registry) }
   let(:raw_user_data) { Hash.new }
+  let(:channel) { Lita::Adapters::Slack::SlackChannel.new('C2147483705', 'general', 1360782804, 'U023BECGF', raw_data) }
+  let(:raw_data) { Hash.new }
+  let(:channel_mapping) { Lita::Adapters::Slack::ChannelMapping.new([channel]) }
+
   let(:rtm_start_response) do
     Lita::Adapters::Slack::TeamData.new(
       [],
       Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', nil, raw_user_data),
       [Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', '', raw_user_data)],
+      [channel],
       "wss://example.com/"
     )
   end
@@ -94,7 +99,9 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
       allow(Lita::Adapters::Slack::MessageHandler).to receive(:new).with(
         robot,
         'U12345678',
-        {}
+        {},
+        channel_mapping
+
       ).and_return(message_handler)
 
       expect(message_handler).to receive(:handle)

--- a/spec/lita/adapters/slack/slack_channel_spec.rb
+++ b/spec/lita/adapters/slack/slack_channel_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe Lita::Adapters::Slack::SlackChannel do
+  let(:channel_data_1) do
+    {
+        "id" => "C2147483705",
+        "name" => "Room 1",
+        "created" => 1360782804,
+        "creator" => 'U023BECGF'
+    }
+  end
+  let(:channel_data_2) do
+    {
+        "id" => "C2147483706",
+        "name" => "Room 2",
+        "created" => 1360782805,
+        "creator" => 'U023BECGF'
+    }
+  end
+  let(:channels_data) { [channel_data_1, channel_data_2] }
+
+  describe ".from_data_array" do
+    subject { described_class.from_data_array(channels_data) }
+
+    it "returns an object for each hash of Channel data" do
+      expect(subject.size).to eq(2)
+    end
+
+    it "creates SlackIM objects" do
+      expect(subject[0].id).to eq('C2147483705')
+      expect(subject[0].name).to eq('Room 1')
+      expect(subject[0].creator).to eq('U023BECGF')
+      expect(subject[0].created).to eq(1360782804)
+      expect(subject[1].id).to eq('C2147483706')
+      expect(subject[1].name).to eq('Room 2')
+      expect(subject[1].creator).to eq('U023BECGF')
+      expect(subject[1].created).to eq(1360782805)
+    end
+  end
+end


### PR DESCRIPTION
Currently url formatting breaks plugins like whois which require original un-formatted url to work.
<http://www.domain.com|www.domain.com> -> www.domain.com
<http://www.domain.com> -> http://www.domain.com

This only un-formats urls. more work would be needed to unformat every thing else that slacks chat engine changes. if slack changes its formating in the future this will break!

this should make most plugins that use urls work. 

sorry I currently have no l clue how to test this 

