### PR TITLE
Only update robot name, mention_name if not set in config

### DIFF
--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -25,8 +25,8 @@ module Lita
           end
 
           def update_robot(robot, slack_user)
-            robot.name = slack_user.real_name
-            robot.mention_name = slack_user.name
+            robot.name = slack_user.real_name unless robot.name
+            robot.mention_name = slack_user.name unless robot.mention_name
           end
         end
       end


### PR DESCRIPTION
lita-slack should not update robot name if that name is explicitly set in config file.

In our setup we have a bot @theodore with a name 'Theodore "Siri" Dreiser'. 
That's cool names, but when we address the bot, we would like to type something shorter, like "teo, help" or "siri, help". Unfortunately, rev. 49cb5ae82902d19cf7367aec004946ed250abc1d took away that possibility.