### PR TITLE
<@UNIQUEID> should be translated to @mention_name not @name.

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -70,7 +70,7 @@ module Lita
                 else
                   user = User.find_by_id(link)
                   if user
-                    "@#{user.name}"
+                    "@#{user.mention_name}"
                   else
                     "@#{link}"
                   end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -193,7 +193,7 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
 
         end
 
-        context "changes <@123> links to @name" do
+        context "changes <@123> links to @label" do
           let(:data) do
             {
                 "type"    => "message",
@@ -204,7 +204,7 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           it "removes formatting" do
             expect(Lita::Message).to receive(:new).with(
                                          robot,
-                                         "foo @name bar",
+                                         "foo @label bar",
                                          source
                                      ).and_return(message)
 


### PR DESCRIPTION
This fixes #45. 

If a user mentions @erik, Slack hands this off as &lt;@UNIQUEID&gt;, we should expand it back to @erik, not @Erik Ogan.