### PR TITLE
Add email to user metadata

### DIFF
--- a/lib/lita-slack.rb
+++ b/lib/lita-slack.rb
@@ -1,4 +1,5 @@
 require "lita"
+require "lita_ext/user"
 
 Lita.load_locales Dir[File.expand_path(
   File.join("..", "..", "locales", "*.yml"), __FILE__

--- a/lib/lita/adapters/slack/slack_user.rb
+++ b/lib/lita/adapters/slack/slack_user.rb
@@ -8,6 +8,7 @@ module Lita
               user_data['id'],
               user_data['name'],
               user_data['real_name'],
+              user_data.fetch('profile', {})['email'],
               user_data
             )
           end
@@ -20,12 +21,14 @@ module Lita
         attr_reader :id
         attr_reader :name
         attr_reader :real_name
+        attr_reader :email
         attr_reader :raw_data
 
-        def initialize(id, name, real_name, raw_data)
+        def initialize(id, name, real_name, email, raw_data)
           @id = id
           @name = name
           @real_name = real_name.to_s
+          @email = email
           @raw_data = raw_data
         end
       end

--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -7,7 +7,8 @@ module Lita
             User.create(
               slack_user.id,
               name: real_name(slack_user),
-              mention_name: slack_user.name
+              mention_name: slack_user.name,
+              email: slack_user.email
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id

--- a/lib/lita_ext/user.rb
+++ b/lib/lita_ext/user.rb
@@ -1,0 +1,27 @@
+# Monkey patch for slack `User` class to add support for searching for users by e-mail.
+
+class Lita::User
+  save_method = self.instance_method(:save)
+
+  define_method(:save) do
+    raise 'Error with monkey patch for `User#save` - expected arity to be 0, ' +
+        "but it is #{save_method.arity}" unless save_method.arity == 0
+
+    # Call the original
+    save_method.bind(self).call
+
+    email = metadata[:email] || metadata["email"]
+
+    # Now save the user's email address as well.
+    redis.set("email:#{email}", id) if email
+  end
+
+  # Finds a user by e-mail address.
+  # @param email [String] The user's e-mail address.
+  # @return [Lita::User, nil] The user or +nil+ if no such user is known.
+  def self.find_by_email(email)
+    id = redis.get("email:#{email}")
+    find_by_id(id) if id
+  end
+end
+

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -21,8 +21,8 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   let(:rtm_start_response) do
     Lita::Adapters::Slack::TeamData.new(
       [],
-      Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', nil, raw_user_data),
-      [Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', '', raw_user_data)],
+      Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', nil, nil, raw_user_data),
+      [Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', '', nil, raw_user_data)],
       [channel],
       "wss://example.com/"
     )

--- a/spec/lita/adapters/slack/user_creator_spec.rb
+++ b/spec/lita/adapters/slack/user_creator_spec.rb
@@ -13,15 +13,17 @@ describe Lita::Adapters::Slack::UserCreator do
 
   describe ".create_users" do
     let(:real_name) { 'Bobby Tables' }
-    let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, slack_data) }
+    let(:email) { 'bobby.tables@foo.com' }
+    let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, email, slack_data) }
     let(:robot_id) { 'U12345678' }
-    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name } }
+    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name, 'profile' => { 'email' => email } } }
 
     it "creates Lita users for each user in the provided data" do
       expect(Lita::User).to receive(:create).with(
         'U023BECGF',
         name: 'Bobby Tables',
-        mention_name: 'bobby'
+        mention_name: 'bobby',
+        email: email
       )
       expect(robot).to receive(:trigger).with(
         :slack_user_created,
@@ -38,7 +40,8 @@ describe Lita::Adapters::Slack::UserCreator do
         expect(Lita::User).to receive(:create).with(
           'U023BECGF',
           name: 'bobby',
-          mention_name: 'bobby'
+          mention_name: 'bobby',
+          email: email
         )
 
         described_class.create_users([bobby], robot, robot_id)
@@ -49,7 +52,7 @@ describe Lita::Adapters::Slack::UserCreator do
   describe ".create_user" do
     let(:robot_id) { 'U12345678' }
     let(:slack_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot' } }
-    let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot', slack_data) }
+    let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot', nil, slack_data) }
 
     it "updates the robot's name and mention name if it applicable" do
       expect(robot).to receive(:name=).with('Lita Bot')

--- a/spec/lita/lita_ext/user_spec.rb
+++ b/spec/lita/lita_ext/user_spec.rb
@@ -1,0 +1,25 @@
+# Specs for monkey-patches to Lita::User
+require "spec_helper"
+
+describe Lita::User, lita: true do
+  describe ".find_by_email" do
+    it "returns nil if no user matches the provided e-mail address" do
+      expect(described_class.find_by_email("carlthepug")).to be_nil
+    end
+
+    it "returns a user that matches the provided email" do
+      described_class.create(1, email: "carl@pugs.com")
+      user = described_class.find_by_email("carl@pugs.com")
+      expect(user.id).to eq("1")
+    end
+  end
+
+  describe "#save" do
+    subject { described_class.new(1, name: "Carl", mention_name: "carlthepug", email: "carl@pugs.com") }
+
+    it "saves an e-mail address to ID mapping for the user in Redis" do
+      subject.save
+      expect(described_class.redis.get("email:carl@pugs.com")).to eq("1")
+    end
+  end
+end


### PR DESCRIPTION
Updates the `Slack::SlackUser` class with an `email` attribute and monkey-patches the `Lita::User` class such that it saves e-mail addresses to Redis and provides a method to find users by their e-mail addresses.

I'm currently working on a plugin for Lita and Slack that talks to an external API that provides only the e-mail addresses for users.  I forked this project and added the find-by-email capability and thought this might be useful for others.