### PR TITLE
Allow Link formatting via `chat.postMessage`

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -24,6 +24,18 @@ module Lita
           call_api("channels.setTopic", channel: channel, topic: topic)
         end
 
+        def post_message(channel, params)
+          raise "Slack message requires a text param" unless params[:text]
+
+          if params[:attachments]
+            params[:attachments] = JSON.dump(params[:attachments])
+          end
+
+          call_api('chat.postMessage',
+                   { as_user: true,
+                     channel: channel }.merge(params))
+        end
+
         def rtm_start
           response_data = call_api("rtm.start")
 

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -24,16 +24,22 @@ module Lita
           call_api("channels.setTopic", channel: channel, topic: topic)
         end
 
-        def post_message(channel, params)
-          raise "Slack message requires a text param" unless params[:text]
+        def post_message(channel, message)
+          if message.is_a?(String)
+            message = {text:message}
+          else
+            raise "Slack message requires a text param" unless message[:text]
 
-          if params[:attachments]
-            params[:attachments] = JSON.dump(params[:attachments])
+            if params[:attachments]
+              params[:attachments] = JSON.dump(message[:attachments])
+            end
+
           end
+
 
           call_api('chat.postMessage',
                    { as_user: true,
-                     channel: channel }.merge(params))
+                     channel: channel }.merge(message))
         end
 
         def rtm_start


### PR DESCRIPTION
As discussed in #36, Slack's RTM messages don't support link formatting or complex messages such as those with attachments.

Inspired by a quick fork @jaisonerick did a few days ago, this branch sends any message that a) is not a string or b) contains `<.*>` to the API's `chat.postMessage` endpoint. 

It seems to work well for the simple case of link formatting, but I'm open to any thoughts on whether there's a different way to do the split.