### PR TITLE
Adds email address to SlackUser object

### DIFF
--- a/lib/lita/adapters/slack/slack_user.rb
+++ b/lib/lita/adapters/slack/slack_user.rb
@@ -30,14 +30,19 @@ module Lita
         # @return [String] The user's email address, e.g. alice@example.com
         attr_reader :email
         # @return [Hash] The raw user data received from Slack, including many more fields.
-        attr_reader :raw_data
+        attr_reader :metadata
 
-        def initialize(id, name, real_name, raw_data)
+        def initialize(id, name, real_name, metadata)
           @id = id
           @name = name
           @real_name = real_name.to_s
-          @email = raw_data['email'].to_s
-          @raw_data = raw_data
+          @email = metadata['email'].to_s
+          @metadata = metadata
+        end
+
+        # nodoc: backward compatability
+        def raw_data
+          @metadata
         end
       end
     end

--- a/lib/lita/adapters/slack/slack_user.rb
+++ b/lib/lita/adapters/slack/slack_user.rb
@@ -41,9 +41,7 @@ module Lita
         end
 
         # nodoc: backward compatability
-        def raw_data
-          @metadata
-        end
+        alias_method :raw_data, :metadata
       end
     end
   end

--- a/lib/lita/adapters/slack/slack_user.rb
+++ b/lib/lita/adapters/slack/slack_user.rb
@@ -27,6 +27,8 @@ module Lita
         attr_reader :name
         # @return [String] The user's display name, e.g. Alice Bobhart
         attr_reader :real_name
+        # @return [String] The user's email address, e.g. alice@example.com
+        attr_reader :email
         # @return [Hash] The raw user data received from Slack, including many more fields.
         attr_reader :raw_data
 
@@ -34,6 +36,7 @@ module Lita
           @id = id
           @name = name
           @real_name = real_name.to_s
+          @email = raw_data['email'].to_s
           @raw_data = raw_data
         end
       end

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -15,8 +15,8 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   let(:registry) { Lita::Registry.new }
   let(:robot) { Lita::Robot.new(registry) }
   let(:raw_user_data) { Hash.new }
-  let(:channel) { Lita::Adapters::Slack::SlackChannel.new('C2147483705', 'general', 1360782804, 'U023BECGF', raw_data) }
-  let(:raw_data) { Hash.new }
+  let(:channel) { Lita::Adapters::Slack::SlackChannel.new('C2147483705', 'general', 1360782804, 'U023BECGF', metadata) }
+  let(:metadata) { Hash.new }
 
   let(:rtm_start_response) do
     Lita::Adapters::Slack::TeamData.new(

--- a/spec/lita/adapters/slack/slack_user_spec.rb
+++ b/spec/lita/adapters/slack/slack_user_spec.rb
@@ -34,5 +34,9 @@ describe Lita::Adapters::Slack::SlackUser do
       expect(subject[1].real_name).to eq('')
       expect(subject[1].email).to eq('')
     end
+
+    it "raw_data matches the metadata" do
+      expect(subject[0].metadata['email']).to eq(subject[0].raw_data['email'])
+    end
   end
 end

--- a/spec/lita/adapters/slack/slack_user_spec.rb
+++ b/spec/lita/adapters/slack/slack_user_spec.rb
@@ -5,7 +5,8 @@ describe Lita::Adapters::Slack::SlackUser do
     {
       "id" => "U023BECGF",
       "name" => "bobby",
-      "real_name" => "Bobby Tables"
+      "real_name" => "Bobby Tables",
+      "email" => "btables@example.com"
     }
   end
   let(:user_data_2) do
@@ -27,9 +28,11 @@ describe Lita::Adapters::Slack::SlackUser do
       expect(subject[0].id).to eq('U023BECGF')
       expect(subject[0].name).to eq('bobby')
       expect(subject[0].real_name).to eq('Bobby Tables')
+      expect(subject[0].email).to eq('btables@example.com')
       expect(subject[1].id).to eq('U024BE7LH')
       expect(subject[1].name).to eq('carl')
       expect(subject[1].real_name).to eq('')
+      expect(subject[1].email).to eq('')
     end
   end
 end

--- a/spec/lita/adapters/slack/user_creator_spec.rb
+++ b/spec/lita/adapters/slack/user_creator_spec.rb
@@ -13,9 +13,10 @@ describe Lita::Adapters::Slack::UserCreator do
 
   describe ".create_users" do
     let(:real_name) { 'Bobby Tables' }
+    let(:email) { 'bobby@example.com' }
     let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, slack_data) }
     let(:robot_id) { 'U12345678' }
-    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name } }
+    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name, 'email' => email } }
 
     it "creates Lita users for each user in the provided data" do
       expect(Lita::User).to receive(:create).with(
@@ -48,7 +49,7 @@ describe Lita::Adapters::Slack::UserCreator do
 
   describe ".create_user" do
     let(:robot_id) { 'U12345678' }
-    let(:slack_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot' } }
+    let(:slack_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot', 'email' => 'litabot@example.com' } }
     let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot', slack_data) }
 
     it "updates the robot's name and mention name if it applicable" do


### PR DESCRIPTION
Adds the user's email address to the available attributes on a SlackUser. Slack always requires an email address, as far as I can tell, for user accounts so this should be safe to be here.  This could be a potentially breaking change since it changes the initializer for SlackUser though.

This is related to #22. 

@kenjij 
cc/ @byroot @Sirupsen