### PR TITLE
Add the entire Slack profile as Lita::User metadata

### DIFF
--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -5,10 +5,13 @@ module Lita
       class UserCreator
         class << self
           def create_user(slack_user, robot, robot_id)
+            profile = slack_user.metadata['profile'] || {}
             User.create(
               slack_user.id,
-              name: real_name(slack_user),
-              mention_name: slack_user.name
+              profile.merge(
+                name: real_name(slack_user),
+                mention_name: slack_user.name,
+              ),
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id

--- a/spec/lita/adapters/slack/user_creator_spec.rb
+++ b/spec/lita/adapters/slack/user_creator_spec.rb
@@ -16,13 +16,14 @@ describe Lita::Adapters::Slack::UserCreator do
     let(:email) { 'bobby@example.com' }
     let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, slack_data) }
     let(:robot_id) { 'U12345678' }
-    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name, 'email' => email } }
+    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name, 'profile' => { 'email' => email } } }
 
     it "creates Lita users for each user in the provided data" do
       expect(Lita::User).to receive(:create).with(
         'U023BECGF',
         name: 'Bobby Tables',
-        mention_name: 'bobby'
+        mention_name: 'bobby',
+        'email' => email,
       )
       expect(robot).to receive(:trigger).with(
         :slack_user_created,
@@ -39,7 +40,8 @@ describe Lita::Adapters::Slack::UserCreator do
         expect(Lita::User).to receive(:create).with(
           'U023BECGF',
           name: 'bobby',
-          mention_name: 'bobby'
+          mention_name: 'bobby',
+          'email' => email,
         )
 
         described_class.create_users([bobby], robot, robot_id)
@@ -49,7 +51,7 @@ describe Lita::Adapters::Slack::UserCreator do
 
   describe ".create_user" do
     let(:robot_id) { 'U12345678' }
-    let(:slack_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot', 'email' => 'litabot@example.com' } }
+    let(:slack_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot', 'profile' => { 'email' => 'litabot@example.com' } } }
     let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot', slack_data) }
 
     it "updates the robot's name and mention name if it applicable" do


### PR DESCRIPTION
Look like we got the Slack payload wrong. The email is actually nested inside the `profile` key.

@jimmycuadra @pallan @sirupsen for review please.