### PR TITLE
Adds parse option to #send_messages

### DIFF
--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -118,6 +118,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
 
   describe "#send_messages" do
     let(:message_json) { MultiJson.dump(id: 1, type: 'message', text: 'hi', channel: channel_id) }
+    let(:msg_parse_mode_json) { MultiJson.dump(id: 1, type: 'message', text: 'hi', channel: channel_id, parse: 'none') }
     let(:channel_id) { 'C024BE91L' }
     let(:websocket) { instance_double("Faye::WebSocket::Client") }
 
@@ -142,6 +143,14 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
         expect do
           subject.send_messages(channel_id, ['x' * 16_001])
         end.to raise_error(ArgumentError)
+      end
+    end
+
+    it "writes the parse mode if supplied" do
+      with_websocket(subject, queue) do |websocket|
+        expect(websocket).to receive(:send).with(msg_parse_mode_json)
+
+        subject.send_messages(channel_id, ['hi', {parse: "none"}])
       end
     end
   end


### PR DESCRIPTION
By default slack escapes strings that are sent to it. For example, if I want to send a long link to Slack with a text anchor in the format `<http://link/goes/here|foo>` it will be displayed just as it was sent instead of as a text link. As far as I can tell from the Slack docs (and google) we can send a `parse` option with the payload to tell slack to leave the message alone. This is my initial work to implement support for this argument.  To use, simply add the `parse` option to the end of your `reply*` methods:

```
response.reply("my message with a <http://link/goes/here|foo>", parse: 'none')
```

This would only work for Slack at this point and this _could_ potentially be moved up into Lita itself so that any adapter could take advantage of it. I decided to start small to get the discussion going.

ping @kenjij @methodmissing @byroot for some :eyes: on this.