### PR TITLE
Add mention_format method

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -15,6 +15,10 @@ module Lita
         ChatService.new(config)
       end
 
+      def mention_format(name)
+        "@#{name}"
+      end
+
       # Starts the connection.
       def run
         return if rtm_connection

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0.0"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", ">= 0.9.2"
   spec.add_development_dependency "coveralls"
 end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -27,6 +27,12 @@ describe Lita::Adapters::Slack, lita: true do
     end
   end
 
+  describe "#mention_format" do
+    it "returns the name prefixed with an @" do
+      expect(subject.mention_format("carl")).to eq("@carl")
+    end
+  end
+
   describe "#run" do
     it "starts the RTM connection" do
       expect(rtm_connection).to receive(:run)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "simplecov"
 require "coveralls"
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
A while back, Lita [added the ability](https://github.com/litaio/lita/commit/51a4b7b773a167c2a2cc9de7a09722ddb071008f#diff-a33353c254ef9eda5f85b76262531d85) to call mention_format on adapters, to better handle referencing a user on a service.  Here's a PR to add the same to this adapter.