### PR TITLE
Subteam mentions

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -54,7 +54,9 @@ module Lita
           # https://api.slack.com/docs/formatting
           message = message.gsub(/
               <                    # opening angle bracket
-              (?<type>[@#!])?      # link type
+              (?<type>[@#!]        # start of type
+                  (?:\w+\^)?       # optional subtype
+              )?                   # end of type
               (?<link>[^>|]+)      # link
               (?:\|                # start of |label (optional)
                   (?<label>[^>]+)  # label
@@ -91,6 +93,9 @@ module Lita
 
               when '!'
                 "@#{link}" if ['channel', 'group', 'everyone'].include? link
+
+              when '!subteam^'
+                label
               else
                 link = link.gsub /^mailto:/, ''
                 if label && !(link.include? label)

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -323,6 +323,24 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           end
         end
 
+        context "changes <!subteam…> links to @group_name" do
+          let(:data) do
+            {
+                "type"    => "message",
+                "channel" => "C2147483705",
+                "text"    => "foo <!subteam^S0DFLF55X|@group_name> bar",
+            }
+          end
+          it "removes formatting" do
+            expect(Lita::Message).to receive(:new).with(
+                                         robot,
+                                         "foo @group_name bar",
+                                         source
+                                     ).and_return(message)
+            subject.handle
+          end
+        end
+
         context "removes remove formatting around <http> links" do
           let(:data) do
             {


### PR DESCRIPTION
Slack supports links to sub-teams, of the form: `<!subteam^link|@team_name>`. This seems to be the least invasive method to support this in a way that has a chance of supporting similar links in the future.

Thanks!